### PR TITLE
Make the AutoObjectSubForm a mixin class.

### DIFF
--- a/plone/autoform/form.py
+++ b/plone/autoform/form.py
@@ -1,5 +1,4 @@
 from zope.interface import implements
-from z3c.form.object import ObjectSubForm
 
 from plone.z3cform.fieldsets.extensible import ExtensibleForm
 
@@ -31,8 +30,8 @@ class AutoExtensibleForm(AutoFields, ExtensibleForm):
         super(AutoExtensibleForm, self).updateFields()
 
 
-class AutoObjectSubForm(AutoFields, ObjectSubForm):
-    """A class for z3c.form.object.ObjectSubForm that supports fields being
+class AutoObjectSubForm(AutoFields):
+    """A Mixin class for z3c.form.object.ObjectSubForm forms that supports fields being
     updated from hints in a schema.
     """
 

--- a/plone/autoform/interfaces.py
+++ b/plone/autoform/interfaces.py
@@ -48,8 +48,8 @@ class IAutoExtensibleForm(Interface):
                                            required=False)
 
 class IAutoObjectSubForm(Interface):
-    """This class enables the z3c.form.object.ObjectSubForm form to also be
-    updated with form hints. See subform.txt
+    """This mixin class enables a form based on z3c.form.object.ObjectSubForm
+    to also have its fields updated with form hints. See subform.txt
     """
 
     schema = zope.schema.Object(title=u"Schema providing form fields",

--- a/plone/autoform/subform.txt
+++ b/plone/autoform/subform.txt
@@ -76,6 +76,7 @@ the permission checks will be turned off.
 Now we define a TestForm, and a TestObjectSubForm. The object subform must
 subclass from AutoObjectSubForm for the form hints to be generated.
 
+    >>> from z3c.form.object import ObjectSubForm
     >>> from plone.autoform.form import AutoExtensibleForm
     >>> from plone.autoform.form import AutoObjectSubForm
     >>> from z3c.form import form
@@ -89,7 +90,7 @@ subclass from AutoObjectSubForm for the form hints to be generated.
     >>> TestForm.mode
     'input'
 
-    >>> class TestObjectSubForm(AutoObjectSubForm):
+    >>> class TestObjectSubForm(AutoObjectSubForm, ObjectSubForm):
     ...     pass
 
 


### PR DESCRIPTION
I'm sorry that my previous commits got merged with the master branch. I'm not sure how that happened.

I made a local git branch and then did a push:

> git push origin jcbrand-objectsubform

which I thought would automatically create and push to a remote branch on github. Well, it did create that branch, but also automatically merged it with the master branch. 

In any case, my changes to plone.autoform let z3c.form.object.ObjectSubForm forms also accept form hints.

_The changes:_

I added a new mixin-class AutoObjectSubForm. If you are creating your own ObjectSubForm (collective.z3cform.datagridfield does this for example), and you want form hints enabled, then you should use this mixin class.

I've added tests in subform.txt

This specific change that I'm making a pull request for, is just to make AutoObjectSubForm a mixin class, and not a subclass of ObjectSubForm.
