### PR TITLE
Zope4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ New:
 
 Fixes:
 
-- *add item here*
+- Test fix test for changed ``zope.interface`` comparison method, which incorrectly reports two different Interfaces from the same module but with empty name as being equal.
+  [thet]
 
 
 1.6.1 (2014-10-20)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ New:
 
 Fixes:
 
-- Test fix test for changed ``zope.interface`` comparison method, which incorrectly reports two different Interfaces from the same module but with empty name as being equal.
+- Fix test for changed ``zope.interface`` comparison method, which incorrectly reports two different Interfaces from the same module but with empty name as being equal.
   [thet]
 
 

--- a/plone/autoform/autoform.txt
+++ b/plone/autoform/autoform.txt
@@ -385,6 +385,9 @@ condition for group naming when autoGroups is True.
     ...
     >>> IAnotherAnonymousSchema.__name__ = ''
 
+Fix for https://github.com/zopefoundation/zope.interface/issues/31
+    >>> IAnotherAnonymousSchema.__module__ = 'different.module'
+
     Create an extrinsicly stored name mapping:
 
     >>> nameToSchema = {


### PR DESCRIPTION
Test fix test for changed zope.interface comparison method, which incorrectly reports two different Interfaces from the same module but with empty name as being equal.