### PR TITLE
Sane ordering for fields.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,14 +1,29 @@
 Changelog
 =========
 
-1.6.3 (unreleased)
+1.7.0 (unreleased)
 ------------------
+
+Incompatibilities:
+
+- Because of the ordering fix the field order in forms may be different.
+  Before this fix the order was a gamble dependent on schema order.
+  Schema form hints ``order_after`` and ``order_before`` may need minor adjustments.
+  ``plone.autoform.utils.processFieldMoves`` was deprecated,
+  but still works as before.
+  The new functionality is now part of ``plone.autoform.base.AutoFields``.
+  [jensens]
 
 New:
 
 - *add item here*
 
 Fixes:
+
+- Implementation on how field ordering happens was unreproducible if same schemas are coming in in different orders.
+  New implementation build a well defined rule tree and processes then the field moves,
+  almost independent from the schema order.
+  [jensens]
 
 - Update setup.py url
   [esteele]

--- a/plone/autoform/autoform.rst
+++ b/plone/autoform/autoform.rst
@@ -6,7 +6,7 @@ in tagged values on schema interfaces. A special form base class is used to
 set up the 'fields' and 'groups' properties on form instances.
 
 The tagged values are stored under keys represented by the following
-constants:
+constants::
 
     >>> from plone.autoform.interfaces import OMITTED_KEY
     >>> from plone.autoform.interfaces import WIDGETS_KEY
@@ -16,7 +16,7 @@ constants:
     >>> from plone.autoform.interfaces import WRITE_PERMISSIONS_KEY
 
 In addition, field groups are constructed from plone.supermodel fieldsets,
-which are also stored in tagged values, under the following constant:
+which are also stored in tagged values, under the following constant::
 
     >>> from plone.supermodel.interfaces import FIELDSETS_KEY
 
@@ -33,7 +33,8 @@ For the purposes of this test, we'll set the form data manually.
 Test setup
 ----------
 
-First, let's load this package's ZCML so that we can run the tests:
+First, let's load this package's ZCML so that we can run the tests::
+
     >>> configuration = """\
     ... <configure xmlns="http://namespaces.zope.org/zope">
     ...
@@ -46,7 +47,7 @@ First, let's load this package's ZCML so that we can run the tests:
     >>> from zope.configuration import xmlconfig
     >>> xmlconfig.xmlconfig(StringIO(configuration))
 
-We also need a few sample interfaces:
+We also need a few sample interfaces::
 
     >>> from zope.interface import Interface
     >>> from zope import schema
@@ -70,7 +71,7 @@ We also need a few sample interfaces:
     ...     six = schema.TextLine(title=u"Six")
 
 And a test context and request, marked with the ``IFormLayer`` interface to
-make z3c.form happy:
+make z3c.form happy::
 
     >>> from zope.publisher.browser import TestRequest
     >>> from z3c.form.interfaces import IFormLayer
@@ -81,7 +82,7 @@ Note that we need to pretend that we have authenticated a user. Without this,
 the permission checks will be turned off. This is to support setting up a form
 pre-traversal in the ++widget++ namespace in plone.z3cform.
 
-And finally, a form:
+And finally, a form::
 
     >>> from z3c.form.interfaces import IForm, IEditForm
     >>> from plone.autoform.form import AutoExtensibleForm
@@ -92,7 +93,7 @@ And finally, a form:
     ...
     ...     ignoreContext = True
 
-This form is in input mode:
+This form is in input mode::
 
     >>> TestForm.mode
     'input'
@@ -102,35 +103,41 @@ Adding form data
 
 Form data can be held under the following keys:
 
-    OMITTED_KEY -- A list of (interface, fieldName, boolean) triples. If the
-        third value evaluates to true, the field with the given fieldName will
-        be omitted from forms providing the given interface.
+OMITTED_KEY
+    A list of (interface, fieldName, boolean) triples.
+    If the third value evaluates to true,
+    the field with the given fieldName will be omitted from forms providing the given interface.
 
-    MODES_KEY -- A list of (interface, fieldName, mode string) triples. A mode
-        string may be one of the z3c.form widget modes, including 'hidden',
-        'input', and 'display'.  The field will be rendered using a widget in
-        the specified mode on forms providing the given interface.
+MODES_KEY
+    A list of (interface, fieldName, mode string) triples.
+    A mode string may be one of the z3c.form widget modes,
+    including 'hidden', 'input', and 'display'.
+    The field will be rendered using a widget in the specified mode on forms providing the given interface.
 
-    WIDGETS_KEY -- A dict of fieldName => widget. The widget can be
-        the dotted name of a z3c.form field widget factory, or an actual
-        instance of one.
+WIDGETS_KEY
+    A dict of fieldName => widget.
+    The widget can be the dotted name of a z3c.form field widget factory,
+    or an actual instance of one.
 
-    ORDER_KEY -- A list of (fieldName, direction, relative_to) triples.
-        direction can be one of 'before' or 'after'. relative_to can be '*'
-        (any/all fields), or the name of a field to move the given field
-        before or after in the form.
+ORDER_KEY
+    A list of (fieldName, direction, relative_to) triples.
+    'direction' can be one of ``before`` or ``after``.
+    relative_to can be ``*`` (any/all fields),
+    or the name of a field to move the given field before or after in the form.
 
-    READ_PERMISSIONS_KEY -- A dict of fieldName => permission id. When a
-        form is in 'display' mode, the field will be omitted unless the user
-        has the given permission in the form's context. The permission id
-        should be a Zope 3 style IPermission utility name, not a Zope 2
-        permission string.
+READ_PERMISSIONS_KEY
+    A dict of fieldName => permission id.
+    When a form is in 'display' mode,
+    the field will be omitted unless the user has the given permission in the form's context.
+    The permission id should be a Zope 3 style IPermission utility name,
+    not a Zope 2 permission string.
 
-    WRITE_PERMISSIONS_KEY -- A dict of fieldName => permission id. When a
-        form is in 'input' mode, the field will be omitted unless the user
-        has the given permission in the form's context. The permission id
-        should be a Zope 3 style IPermission utility name, not a Zope 2
-        permission string.
+WRITE_PERMISSIONS_KEY
+    A dict of fieldName => permission id.
+    When a form is in 'input' mode,
+    the field will be omitted unless the user has the given permission in the form's context.
+    The permission id should be a Zope 3 style IPermission utility name,
+    not a Zope 2 permission string.
 
 Note that 'order' directives are processed after all schemata in the form are
 set up. Ordering will start by going through the additionalSchemata in order.
@@ -154,12 +161,15 @@ This contains a list of ``plone.supermodel.model.Fieldset`` instances.
 At this point, there is no form data. When the form is updated, the 'fields'
 and 'groups' properties will be set.
 
+::
+
     >>> test_form = TestForm(context, request)
     >>> test_form.update()
     >>> test_form.fields.keys()
     ['one', 'two', 'three', 'four', 'five', 'six',
      'ISupplementarySchema.one', 'ISupplementarySchema.two',
-     'IOtherSchema.three', 'IOtherSchema.four', 'IOtherSchema.five', 'IOtherSchema.six']
+     'IOtherSchema.three', 'IOtherSchema.four',
+     'IOtherSchema.five', 'IOtherSchema.six']
     >>> test_form.groups
     ()
 
@@ -168,7 +178,7 @@ from the additional schemata have been prefixed with the schema dotted name.
 
 Let us now set up some form data.
 
-Omitted fields are listed like this:
+Omitted fields are listed like this::
 
     >>> ITestSchema.setTaggedValue(OMITTED_KEY,
     ...                            ((IForm, 'four', True),
@@ -177,7 +187,7 @@ Omitted fields are listed like this:
     ...                             (Interface, 'five', True))
     ...                           )
 
-Field modes can be set like this:
+Field modes can be set like this::
 
     >>> ITestSchema.setTaggedValue(MODES_KEY,
     ...                            ((Interface, 'one', 'display'),
@@ -186,21 +196,50 @@ Field modes can be set like this:
     ...                             (Interface, 'two', 'display'))
     ...                           )
 
-Widgets can be specified either by a dotted name string or an actual instance:
+Widgets can be specified either by a dotted name string or an actual instance::
 
     >>> from z3c.form.browser.password import PasswordFieldWidget
     >>> ITestSchema.setTaggedValue(WIDGETS_KEY, {'two': PasswordFieldWidget})
     >>> IOtherSchema.setTaggedValue(WIDGETS_KEY, {'five': 'z3c.form.browser.password.PasswordFieldWidget'})
 
-Fields can be moved like this:
+Fields can be moved like this::
 
-    >>> IOtherSchema.setTaggedValue(ORDER_KEY, [('four', 'before', 'ISupplementarySchema.one'),
-    ...                                         ('five', 'after', '.six',)])
+    >>> ITestSchema.setTaggedValue(
+    ...     ORDER_KEY,
+    ...     [('one', 'after', 'two')]
+    ... )
 
-    >>> ISupplementarySchema.setTaggedValue(ORDER_KEY, [('one', 'before', '*'),
-    ...                                                 ('two', 'before', 'one')])
+    >>> IOtherSchema.setTaggedValue(
+    ...     ORDER_KEY,
+    ...     [
+    ...         ('four', 'before', 'ISupplementarySchema.one'),
+    ...         ('five', 'after', '.six',)
+    ...     ]
+    ... )
 
-    >>> ITestSchema.setTaggedValue(ORDER_KEY,          [('one', 'after', 'two')])
+    >>> ISupplementarySchema.setTaggedValue(
+    ...     ORDER_KEY,
+    ...     [
+    ...         ('one', 'before', '*'),
+    ...         ('two', 'before', 'one')
+    ...     ]
+    ... )
+
+
+    >>> test_form = TestForm(context, request)
+    >>> test_form.update()
+    >>> test_form.fields.keys()
+    ['IOtherSchema.four',
+    'ISupplementarySchema.one',
+    'two',
+    'ISupplementarySchema.two',
+    'one',
+    'three',
+    'five',
+    'six',
+    'IOtherSchema.three',
+    'IOtherSchema.six',
+    'IOtherSchema.five']
 
 Note how the second value of each tuple refers to the full name with a prefix,
 so the field 'two' from ``ISupplementarySchema`` is moved before the field
@@ -208,33 +247,37 @@ so the field 'two' from ``ISupplementarySchema`` is moved before the field
 ``IOtherSchema``'s field 'five' after the field 'six' in the same schema by
 using a shortcut: '.six' is equivalent to 'IOtherSchema.six' in this case.
 
-Field permissions can be set like this:
+Field permissions can be set like this::
 
-    >>> ITestSchema.setTaggedValue(WRITE_PERMISSIONS_KEY, { 'five': u'dummy.PermissionOne',
-    ...                                                      'six': u'five.ManageSite'})
+    >>> ITestSchema.setTaggedValue(
+    ...     WRITE_PERMISSIONS_KEY,
+    ...     {'five': u'dummy.PermissionOne', 'six': u'five.ManageSite'}
+    ... )
 
 Note that if a permission is not found, the field will be allowed.
 
-Finally, fieldsets are configured like this:
+Finally, fieldsets are configured like this::
 
     >>> from plone.supermodel.model import Fieldset
-    >>> ITestSchema.setTaggedValue(FIELDSETS_KEY,
-    ...                                 [Fieldset('fieldset1', fields=['three'],
-    ...                                           label=u"Fieldset one",
-    ...                                           description=u"Description of fieldset one")])
+    >>> ITestSchema.setTaggedValue(
+    ...     FIELDSETS_KEY,
+    ...     [Fieldset('fieldset1', fields=['three'],
+    ...      label=u"Fieldset one",
+    ...      description=u"Description of fieldset one")])
     >>> IOtherSchema.setTaggedValue(FIELDSETS_KEY, [Fieldset('fieldset1', fields=['three'])])
 
 Note how the label/description need only be specified once.
 
-The results of all of this can be seen below:
+The results of all of this can be seen below::
+
 
     >>> test_form = TestForm(context, request)
     >>> test_form.update()
     >>> test_form.fields.keys()
     ['IOtherSchema.four',
      'ISupplementarySchema.one',
-     'ISupplementarySchema.two',
      'two',
+     'ISupplementarySchema.two',
      'one',
      'five',
      'IOtherSchema.six',
@@ -247,7 +290,7 @@ but then ``IOtherSchema['four']`` was moved before this one again.
 coming between ``ITestSchema['one']`` and ``ITestSchema['two']``.
 
 ``ITestSchema['one']`` was hidden and ``ITestSchema['two']`` was put into
-display mode:
+display mode::
 
     >>> test_form.widgets['one'].mode
     'hidden'
@@ -255,7 +298,7 @@ display mode:
     'display'
 
 ``ITestSchema['two']`` and ``IOtherSchema['five']`` were both given a password
-widget - one by instance, the other by dotted name:
+widget - one by instance, the other by dotted name::
 
     >>> test_form.widgets['two']
     <PasswordWidget 'form.widgets.two'>
@@ -264,7 +307,7 @@ widget - one by instance, the other by dotted name:
     <PasswordWidget 'form.widgets.IOtherSchema.five'>
 
 There is one group corresponding to the fieldset where we put two fields. It
-has taken the label and description from the first definition.
+has taken the label and description from the first definition::
 
     >>> len(test_form.groups)
     1
@@ -292,15 +335,9 @@ return.
     >>> test_form = TestForm(context, request)
     >>> test_form.update()
     >>> test_form.fields.keys()
-    ['IOtherSchema.four',
-     'ISupplementarySchema.one',
-     'ISupplementarySchema.two',
-     'two',
-     'one',
-     'five',
-     'six',
-     'IOtherSchema.six',
-     'IOtherSchema.five']
+    ['IOtherSchema.four', 'ISupplementarySchema.one', 'two',
+    'ISupplementarySchema.two', 'one', 'five', 'six',
+    'IOtherSchema.six', 'IOtherSchema.five']
 
 Automatic field sets
 --------------------

--- a/plone/autoform/base.py
+++ b/plone/autoform/base.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
-from plone.autoform.utils import processFieldMoves, processFields
+from plone.autoform.utils import processFieldMoves
+from plone.autoform.utils import processFields
 from plone.z3cform.fieldsets.group import GroupFactory
 from z3c.form import field
+
 
 _marker = object()
 

--- a/plone/autoform/base.py
+++ b/plone/autoform/base.py
@@ -1,10 +1,17 @@
 # -*- coding: utf-8 -*-
-from plone.autoform.utils import processFieldMoves
+from collections import OrderedDict
+from plone.autoform.interfaces import ORDER_KEY
 from plone.autoform.utils import processFields
+from plone.supermodel.utils import mergedTaggedValueList
 from plone.z3cform.fieldsets.group import GroupFactory
+from plone.z3cform.fieldsets.utils import move
 from z3c.form import field
+from z3c.form.util import expandPrefix
+
+import logging
 
 
+logger = logging.getLogger(__name__)
 _marker = object()
 
 
@@ -38,12 +45,14 @@ class AutoFields(object):
 
         groups = []
 
-        for g in self.groups:
-            group_name = getattr(g, '__name__', g.label)
-            fieldset_group = GroupFactory(group_name,
-                                          field.Fields(g.fields),
-                                          g.label,
-                                          getattr(g, 'description', None))
+        for group in self.groups:
+            group_name = getattr(group, '__name__', group.label)
+            fieldset_group = GroupFactory(
+                group_name,
+                field.Fields(group.fields),
+                group.label,
+                getattr(group, 'description', None)
+            )
             groups.append(fieldset_group)
 
         # Copy to instance variable only after we have potentially read from
@@ -52,63 +61,74 @@ class AutoFields(object):
 
         prefixes = {}
 
-        # Set up all widgets, modes, omitted fields and fieldsets
         if self.schema is not None:
             processFields(self, self.schema, permissionChecks=have_user)
-            for schema in self.additionalSchemata:
 
-                # Find the prefix to use for this form and cache for next round
-                prefix = self.getPrefix(schema)
-                if prefix and prefix in prefixes:
-                    prefix = schema.__identifier__
-                prefixes[schema] = prefix
+        # Set up all widgets, modes, omitted fields and fieldsets
+        for schema in self.additionalSchemata:
 
-                # By default, there's no default group, i.e. fields go
-                # straight into the default fieldset
+            # Find the prefix to use for this form and cache for next round
+            prefix = self.getPrefix(schema)
+            if prefix and prefix in prefixes:
+                prefix = schema.__identifier__
+            prefixes[schema] = prefix
 
-                defaultGroup = None
+            # By default, there's no default group, i.e. fields go
+            # straight into the default fieldset
 
-                # Create groups from schemata if requested and set default
-                # group
+            defaultGroup = None
 
-                if self.autoGroups:
-                    # use interface name, or prefix for anonymous schema
-                    group_name = schema.__name__ or prefix or None
+            # Create groups from schemata if requested and set default
+            # group
 
-                    # Look for group - note that previous processFields
-                    # may have changed the groups list, so we can't easily
-                    # store this in a dict.
-                    found = False
-                    for g in self.groups:
-                        if group_name == getattr(g, '__name__', g.label):
-                            found = True
-                            break
+            if self.autoGroups:
+                # use interface name, or prefix for anonymous schema
+                group_name = schema.__name__ or prefix or None
 
-                    if not found:
-                        fieldset_group = GroupFactory(
-                            group_name,
-                            field.Fields(),
-                            group_name,
-                            schema.__doc__
-                        )
-                        self.groups.append(fieldset_group)
+                # Look for group - note that previous processFields
+                # may have changed the groups list, so we can't easily
+                # store this in a dict.
+                found = False
+                for g in self.groups:
+                    if group_name == getattr(g, '__name__', g.label):
+                        found = True
+                        break
 
-                    defaultGroup = group_name
+                if not found:
+                    fieldset_group = GroupFactory(
+                        group_name,
+                        field.Fields(),
+                        group_name,
+                        schema.__doc__
+                    )
+                    self.groups.append(fieldset_group)
 
-                processFields(
-                    self, schema,
-                    prefix=prefix,
-                    defaultGroup=defaultGroup,
-                    permissionChecks=have_user
-                )
+                defaultGroup = group_name
+
+            processFields(
+                self,
+                schema,
+                prefix=prefix,
+                defaultGroup=defaultGroup,
+                permissionChecks=have_user
+            )
 
         # Then process relative field movements. The base schema is processed
         # last to allow it to override any movements made in additional
         # schemata.
+        rules = None
+        for schema in self.additionalSchemata:
+            order = mergedTaggedValueList(schema, ORDER_KEY)
+            rules = self._calculate_field_moves(
+                order,
+                prefix=prefixes[schema],
+                rules=rules,
+            )
         if self.schema is not None:
-            for schema in self.additionalSchemata:
-                processFieldMoves(self, schema, prefix=prefixes[schema])
-            processFieldMoves(self, self.schema)
+            order = mergedTaggedValueList(self.schema, ORDER_KEY)
+            rules = self._calculate_field_moves(order, rules=rules)
+        self._cleanup_rules(rules)
+        self._process_field_moves(rules)
 
     def getPrefix(self, schema):
         """Get the preferred prefix for the given schema
@@ -116,3 +136,114 @@ class AutoFields(object):
         if self.ignorePrefix:
             return ''
         return schema.__name__
+
+    def _prepare_names(self, source, target, prefix):
+            # calculate prefixed fieldname
+            if prefix:
+                source = '{0}.{1}'.format(prefix, source)
+
+            # Handle shortcut: leading . means "in this form". May be useful
+            # if you want to move a field relative to one in the current
+            # schema or (more likely) a base schema of the current schema,
+            # without having to repeat the full prefix of this schema.
+            if target.startswith('.'):
+                target = target[1:]
+                if prefix:
+                    target = expandPrefix(prefix) + target
+            return source, target
+
+    def _cleanup_rules(self, rules):
+        for rulename in rules['__all__']:
+            if 'parent' in rules['__all__'][rulename]:
+                del rules['__all__'][rulename]['parent']
+        del rules['__all__']
+
+    def _calculate_field_moves(self, order, prefix='', rules=None):
+        """Calculates all needed field rules
+        """
+        # we want to be independent from the order of the schemas coming later
+        # so a if field_c is first moved after field_a, then field_a is moved
+        # after field_c, the output should be: b, a, c, because or first move
+        # sticks
+        if rules is None:
+            rules = {}
+        allrules = rules.get('__all__', None)
+        if allrules is None:
+            allrules = rules['__all__'] = dict()
+
+        # (current field name, 'before'/'after', other field name)
+        for source, direction, target in order:
+            source, target = self._prepare_names(source, target, prefix)
+            # use a simple tree to resolve dependencies
+            rule = allrules.get(source, {})
+            if (
+                'target' in rule and target != rule['target']
+            ):
+                # target override
+                # reset this rule to a stub first
+                del rule['target']
+                del rule['dir']
+                rule['stub'] = True
+                # unlink in parent
+                del rule['parent']['with'][source]
+                del rule['parent']
+            if (
+                'dir' in rule and direction != rule['dir']
+            ):
+                # direction override
+                rule['dir'] = direction
+            if not rule or rule.get('stub', False):
+                if rule.get('stub', False):
+                    del rule['stub']
+                rule['target'] = target
+                rule['dir'] = direction
+                allrules[source] = rule
+
+            # field is no longer a tree root
+            if source in rules:
+                del rules[source]
+
+            target_rule = allrules.get(target, None)
+            if target_rule is None:
+                allrules[target] = target_rule = {
+                    'stub': True,
+                }
+                rules[target] = target_rule
+            if 'with' not in target_rule:
+                target_rule['with'] = OrderedDict()
+            rule['parent'] = target_rule
+            target_rule['with'][source] = rule
+
+        return rules
+
+    def _process_field_moves(self, rules):
+        """move fields according to the rules
+        """
+        for name, rule in rules.items():
+            if name == '__all__':
+                continue
+            prefix = None
+            if '.' in name:
+                prefix, name = name.split('.', 1)
+            else:
+                prefix = ''
+            if not rule.get('stub', False):
+                after = rule['target'] if rule['dir'] == 'after' else None
+                before = rule['target'] if rule['dir'] == 'before' else None
+                if not (before or after):
+                    raise ValueError(
+                        'Direction of a field move must be before or '
+                        'after, but got {0}.'.format(rule['direction'])
+                    )
+                try:
+                    move(self, name, before=before, after=after, prefix=prefix)
+                except KeyError:
+                    # The relative_to field doesn't exist
+                    logger.exception(
+                        'No field move possible for non-existing field named '
+                        '{0} with target {1}'.format(
+                            prefix + '.' + name,
+                            before or after
+                        )
+                    )
+            self._process_field_moves(rule.get('with', {}))

--- a/plone/autoform/directives.py
+++ b/plone/autoform/directives.py
@@ -120,7 +120,7 @@ class widget(MetadataDictDirective):
         if field_name is None:  # Usage 3
             for field_name, widget in kw.items():
                 if not isinstance(widget, basestring):
-                    widget = "%s.%s" % (widget.__module__, widget.__name__)
+                    widget = '%s.%s' % (widget.__module__, widget.__name__)
                 widgets[field_name] = widget
         else:
             if widget_class is not None \

--- a/plone/autoform/form.py
+++ b/plone/autoform/form.py
@@ -5,6 +5,7 @@ from plone.autoform.interfaces import IAutoObjectSubForm
 from plone.z3cform.fieldsets.extensible import ExtensibleForm
 from zope.interface import implementer
 
+
 _marker = object()
 
 

--- a/plone/autoform/form.py
+++ b/plone/autoform/form.py
@@ -20,8 +20,8 @@ class AutoExtensibleForm(AutoFields, ExtensibleForm):
     @property
     def schema(self):
         raise NotImplementedError(
-            "The class deriving from AutoExtensibleForm must have a "
-            "'schema' property"
+            'The class deriving from AutoExtensibleForm must have a '
+            '\'schema\' property'
         )
 
     @property

--- a/plone/autoform/interfaces.py
+++ b/plone/autoform/interfaces.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 from plone.supermodel.interfaces import IFieldset
+from z3c.form.interfaces import IDisplayForm
+from z3c.form.interfaces import IFieldsForm
 from z3c.form.interfaces import IFieldWidget
-from z3c.form.interfaces import IFieldsForm, IDisplayForm, IWidget
+from z3c.form.interfaces import IWidget
 from zope.interface import Interface
 from zope.interface.interfaces import IInterface
+
 import zope.schema
+
 
 # Schema interface tagged value keys
 MODES_KEY = u"plone.autoform.modes"

--- a/plone/autoform/supermodel.py
+++ b/plone/autoform/supermodel.py
@@ -14,10 +14,12 @@ from plone.autoform.utils import resolveDottedName
 from plone.autoform.widgets import ParameterizedWidget
 from plone.supermodel.parser import IFieldMetadataHandler
 from plone.supermodel.utils import ns
-from z3c.form.interfaces import IFieldWidget, IValidator
+from z3c.form.interfaces import IFieldWidget
+from z3c.form.interfaces import IValidator
 from z3c.form.util import getSpecification
 from zope.component import provideAdapter
-from zope.interface import implements, Interface
+from zope.interface import implements
+from zope.interface import Interface
 from zope.interface.interface import InterfaceClass
 
 

--- a/plone/autoform/supermodel.py
+++ b/plone/autoform/supermodel.py
@@ -50,7 +50,7 @@ class FormSchema(object):
                 interface = resolveDottedName(interface_dotted_name)
                 if not isinstance(interface, InterfaceClass):
                     raise ValueError(
-                        "%s not an Interface." % interface_dotted_name)
+                        '%s not an Interface.' % interface_dotted_name)
             else:
                 interface = Interface
             tagged_value.append((interface, name, value))
@@ -60,7 +60,7 @@ class FormSchema(object):
         validator = resolveDottedName(value)
         if not IValidator.implementedBy(validator):
             raise ValueError(
-                "z3c.form.interfaces.IValidator not implemented by %s."
+                'z3c.form.interfaces.IValidator not implemented by %s.'
                 % value)
         provideAdapter(
             validator,
@@ -103,7 +103,7 @@ class FormSchema(object):
         elif widgetAttr is not None:  # BBB for old form:widget attributes
             obj = resolveDottedName(widgetAttr)
             if not IFieldWidget.implementedBy(obj):
-                raise ValueError("IFieldWidget not implemented by %s" % obj)
+                raise ValueError('IFieldWidget not implemented by %s' % obj)
             widget = widgetAttr
         if widget is not None:
             self._add(schema, WIDGETS_KEY, name, widget)
@@ -142,20 +142,20 @@ class FormSchema(object):
         mode_values = []
         for interface, value in mode:
             if interface is not Interface:
-                value = "%s:%s" % (interface.__identifier__, value)
+                value = '%s:%s' % (interface.__identifier__, value)
             mode_values.append(value)
         if mode_values:
-            fieldNode.set(ns('mode', self.namespace), " ".join(mode_values))
+            fieldNode.set(ns('mode', self.namespace), ' '.join(mode_values))
 
         omitted_values = []
         for interface, value in omitted:
             if interface is not Interface:
-                value = "%s:%s" % (interface.__identifier__, value)
+                value = '%s:%s' % (interface.__identifier__, value)
             omitted_values.append(value)
         if omitted_values:
             fieldNode.set(
                 ns('omitted', self.namespace),
-                " ".join(omitted_values)
+                ' '.join(omitted_values)
             )
 
         for direction, relative_to in order:

--- a/plone/autoform/supermodel.py
+++ b/plone/autoform/supermodel.py
@@ -18,15 +18,15 @@ from z3c.form.interfaces import IFieldWidget
 from z3c.form.interfaces import IValidator
 from z3c.form.util import getSpecification
 from zope.component import provideAdapter
-from zope.interface import implements
+from zope.interface import implementer
 from zope.interface import Interface
 from zope.interface.interface import InterfaceClass
 
 
+@implementer(IFieldMetadataHandler)
 class FormSchema(object):
     """Support the form: namespace in model definitions.
     """
-    implements(IFieldMetadataHandler)
 
     namespace = FORM_NAMESPACE
     prefix = FORM_PREFIX
@@ -165,10 +165,10 @@ class FormSchema(object):
                 fieldNode.set(ns('after', self.namespace), relative_to)
 
 
+@implementer(IFieldMetadataHandler)
 class SecuritySchema(object):
     """Support the security: namespace in model definitions.
     """
-    implements(IFieldMetadataHandler)
 
     namespace = SECURITY_NAMESPACE
     prefix = SECURITY_PREFIX

--- a/plone/autoform/testing.py
+++ b/plone/autoform/testing.py
@@ -2,6 +2,7 @@
 from plone.testing import Layer
 from plone.testing import z2
 from plone.testing import zca
+
 import plone.autoform
 
 

--- a/plone/autoform/testing.py
+++ b/plone/autoform/testing.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from plone.testing import Layer
 from plone.testing import z2
 from plone.testing import zca
 
@@ -10,8 +9,8 @@ AUTOFORM_FIXTURE = zca.ZCMLSandbox(
     bases=(z2.STARTUP,),
     filename='configure.zcml',
     package=plone.autoform,
-    name="plone.autoform:Fixture")
+    name='plone.autoform:Fixture')
 
 AUTOFORM_INTEGRATION_TESTING = z2.IntegrationTesting(
     bases=(AUTOFORM_FIXTURE,),
-    name="plone.autoform:Integration")
+    name='plone.autoform:Integration')

--- a/plone/autoform/tests/subform.txt
+++ b/plone/autoform/tests/subform.txt
@@ -100,17 +100,16 @@ Finally we need an adapter that acts as the ObjectSubForm's factory.
     >>> from z3c.form.object import SubformAdapter
     >>> import zope.component
 
-    >>> class TestSubformAdapter(SubformAdapter):
-    ...     """ """
-    ...     zope.interface.implements(interfaces.ISubformFactory)
-    ...     zope.component.adapts(zope.interface.Interface,  # widget value
+    >>> @zope.interface.implementer(interfaces.ISubformFactory)
+    ... @zope.component.adapter(zope.interface.Interface,  # widget value
     ...                         interfaces.IFormLayer,       # request
     ...                         zope.interface.Interface,    # widget context
     ...                         zope.interface.Interface,    # form
     ...                         ObjectWidget,                # widget
     ...                         zope.interface.Interface,    # field
     ...                         zope.interface.Interface)    # field.schema
-    ...
+    ... class TestSubformAdapter(SubformAdapter):
+    ...     """ """
     ...     factory = TestObjectSubForm
 
     >>> zope.component.provideAdapter(TestSubformAdapter)

--- a/plone/autoform/tests/test_base.py
+++ b/plone/autoform/tests/test_base.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+from collections import OrderedDict
+from plone.testing.zca import UNIT_TESTING
+
+import unittest
+
+
+class TestBase(unittest.TestCase):
+
+    layer = UNIT_TESTING
+
+    def test_calc_field_move_basics(self):
+        from plone.autoform.base import AutoFields
+        autofields = AutoFields()
+
+        # we have a schema with fields [a, b, c]
+        # field 'c' after 'a'
+        order = [('c', 'after', 'a'), ]
+        rules = autofields._calculate_field_moves(order)
+        self.assertIn('a', rules)
+        self.assertNotIn('c', rules)
+        self.assertIn('with', rules['a'])
+        self.assertIn('stub', rules['a'])
+        self.assertIn('c', rules['a']['with'])
+        self.assertIn('parent', rules['a']['with']['c'])
+        self.assertIs(rules['a'], rules['a']['with']['c']['parent'])
+        self.assertIn('target', rules['a']['with']['c'])
+        self.assertIn('dir', rules['a']['with']['c'])
+
+    def test_calc_field_move_simple_dependency(self):
+        from plone.autoform.base import AutoFields
+        autofields = AutoFields()
+
+        # we have a schema with fields [a, b, c]
+        # field a after b and field 'c' after 'a'
+        order = [
+            ('a', 'after', 'b'),
+            ('c', 'after', 'a'),
+        ]
+        expected = {
+            'stub': True,
+            'with': OrderedDict(
+                [
+                    (
+                        'a',
+                        {
+                            'with': OrderedDict(
+                                [('c', {'target': 'a', 'dir': 'after'})]
+                            ),
+                            'target': 'b', 'dir': 'after'}
+                    ),
+                ]
+            )
+        }
+        rules = autofields._calculate_field_moves(order)
+        self.assertIn('b', rules)
+        self.assertNotIn('a', rules)
+        self.assertNotIn('c', rules)
+
+        # remove parent key enable comparison of  dicts
+        del rules['__all__']['a']['parent']
+        del rules['__all__']['c']['parent']
+        self.assertEqual(rules['b'], expected)
+
+        # we have a schema with fields [a, b, c]
+        # vice versa defined now, must lead to same result
+        # field 'c' after 'a' and field a after b
+        order = reversed(order)
+        rules = autofields._calculate_field_moves(order)
+        self.assertIn('b', rules)
+        self.assertNotIn('a', rules)
+        self.assertNotIn('c', rules)
+
+        # remove parent key enable comparison of  dicts
+        del rules['__all__']['a']['parent']
+        del rules['__all__']['c']['parent']
+        self.assertEqual(rules['b'], expected)
+
+    def test_calc_field_move_multiple_dependencies(self):
+        from plone.autoform.base import AutoFields
+        autofields = AutoFields()
+
+        order = [
+            ('a', 'after', 'b'),
+            ('c', 'after', 'a'),
+            ('d', 'after', 'c'),
+            ('z', 'after', 'x'),
+            ('x', 'after', 'y'),
+        ]
+        rules = autofields._calculate_field_moves(order)
+        self.assertIn('b', rules)
+        self.assertIn('y', rules)
+        self.assertNotIn('a', rules)
+        self.assertNotIn('c', rules)
+        self.assertNotIn('d', rules)
+        self.assertNotIn('z', rules)
+        self.assertNotIn('x', rules)
+
+        self.assertIn('a', rules['b']['with'])
+        self.assertEqual(1, len(rules['b']['with']))
+
+        self.assertIn('c', rules['b']['with']['a']['with'])
+        self.assertEqual(1, len(rules['b']['with']['a']['with']))
+
+        self.assertIn('d', rules['b']['with']['a']['with']['c']['with'])
+        self.assertEqual(1, len(rules['b']['with']['a']['with']['c']['with']))
+
+    def test_calc_field_move_override(self):
+        from plone.autoform.base import AutoFields
+        autofields = AutoFields()
+
+        order = [
+            ('c', 'after', 'a'),
+            ('a', 'after', 'b'),
+            ('c', 'after', 'z'),
+        ]
+        rules = autofields._calculate_field_moves(order)
+        self.assertIn('b', rules)
+        self.assertIn('z', rules)
+        self.assertNotIn('a', rules)
+        self.assertNotIn('c', rules)

--- a/plone/autoform/tests/test_directives.py
+++ b/plone/autoform/tests/test_directives.py
@@ -84,6 +84,7 @@ class TestSchemaDirectives(unittest.TestCase):
 
         @implementer(IWidget)
         class DummyWidget(object):
+
             def __init__(self, request):
                 pass
 
@@ -103,6 +104,7 @@ class TestSchemaDirectives(unittest.TestCase):
 
         @implementer(IWidget)
         class DummyWidget(object):
+
             def __init__(self, request):
                 pass
 
@@ -211,4 +213,4 @@ class TestSchemaDirectives(unittest.TestCase):
 def test_suite():
     return unittest.TestSuite((
         unittest.makeSuite(TestSchemaDirectives),
-        ))
+    ))

--- a/plone/autoform/tests/test_directives.py
+++ b/plone/autoform/tests/test_directives.py
@@ -9,6 +9,7 @@ from plone.autoform.interfaces import WRITE_PERMISSIONS_KEY
 from plone.autoform.testing import AUTOFORM_INTEGRATION_TESTING
 from plone.supermodel import model
 from zope.interface import Interface
+
 import unittest
 import zope.schema
 

--- a/plone/autoform/tests/test_doctests.py
+++ b/plone/autoform/tests/test_doctests.py
@@ -28,4 +28,4 @@ def test_suite():
                 '../supermodel.txt',
                 optionflags=doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS,),
             layer=UNIT_TESTING),
-        ))
+    ))

--- a/plone/autoform/tests/test_doctests.py
+++ b/plone/autoform/tests/test_doctests.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from plone.testing import layered
 from plone.testing.zca import UNIT_TESTING
+
 import doctest
 import unittest
 

--- a/plone/autoform/tests/test_doctests.py
+++ b/plone/autoform/tests/test_doctests.py
@@ -10,7 +10,7 @@ def test_suite():
     return unittest.TestSuite((
         layered(
             doctest.DocFileSuite(
-                '../autoform.txt',
+                '../autoform.rst',
                 optionflags=doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS,),
             layer=UNIT_TESTING),
         layered(

--- a/plone/autoform/tests/test_supermodel_handler.py
+++ b/plone/autoform/tests/test_supermodel_handler.py
@@ -24,6 +24,7 @@ import zope.schema
 
 @implementer(IWidget)
 class DummyWidget(object):
+
     def __init__(self, request):
         pass
 

--- a/plone/autoform/tests/test_supermodel_handler.py
+++ b/plone/autoform/tests/test_supermodel_handler.py
@@ -15,8 +15,9 @@ from z3c.form.interfaces import IForm
 from z3c.form.interfaces import IValidator
 from z3c.form.interfaces import IWidget
 from zope.component import getMultiAdapter
-from zope.interface import Interface
 from zope.interface import implementer
+from zope.interface import Interface
+
 import unittest2 as unittest
 import zope.schema
 

--- a/plone/autoform/tests/test_utils.py
+++ b/plone/autoform/tests/test_utils.py
@@ -9,7 +9,9 @@ from plone.testing.zca import UNIT_TESTING
 from z3c.form.form import Form
 from z3c.form.validator import SimpleFieldValidator
 from zope.component import provideUtility
-from zope.interface import Interface, Invalid
+from zope.interface import Interface
+from zope.interface import Invalid
+
 import unittest
 import zope.schema
 

--- a/plone/autoform/tests/test_widgets.py
+++ b/plone/autoform/tests/test_widgets.py
@@ -17,6 +17,7 @@ class TestParameterizedWidget(unittest.TestCase):
 
         @implementer(IWidget)
         class DummyWidget(object):
+
             def __init__(self, request):
                 self.request = request
 
@@ -40,6 +41,7 @@ class TestParameterizedWidget(unittest.TestCase):
         from zope.schema import Field
 
         class DummyWidget(object):
+
             def __init__(self, request):
                 self.request = request
 

--- a/plone/autoform/tests/test_widgets.py
+++ b/plone/autoform/tests/test_widgets.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from plone.testing.zca import UNIT_TESTING
+
 import unittest2 as unittest
 
 

--- a/plone/autoform/utils.py
+++ b/plone/autoform/utils.py
@@ -22,6 +22,7 @@ from zope.dottedname.resolve import resolve
 from zope.interface import providedBy
 from zope.security.interfaces import IPermission
 
+
 _dottedCache = {}
 
 

--- a/plone/autoform/utils.py
+++ b/plone/autoform/utils.py
@@ -18,6 +18,7 @@ from z3c.form.interfaces import IFieldWidget
 from z3c.form.interfaces import INPUT_MODE
 from z3c.form.util import expandPrefix
 from zope.component import queryUtility
+from zope.deprecation import deprecate
 from zope.dottedname.resolve import resolve
 from zope.interface import providedBy
 from zope.security.interfaces import IPermission
@@ -257,6 +258,14 @@ def processFields(form, schema, prefix='', defaultGroup=None,
                 groups[fieldset.__name__].fields += newFields
 
 
+@deprecate(
+    'processFieldMoves must not be used any longer. Its implementation is '
+    'unreproducible if same schemas are coming in in different orders. '
+    'The new solution is part of the base.AutoFields class and does '
+    'follow strict rules by first creating a rule dependency tree.'
+    'This function will be remove in a 2.0 releaese and kept until then for '
+    'backward compatibility reasons.'
+)
 def processFieldMoves(form, schema, prefix=''):
     """Process all field moves stored under ORDER_KEY in the schema tagged
     value. This should be run after all schemata have been processed with
@@ -265,10 +274,9 @@ def processFieldMoves(form, schema, prefix=''):
 
     # (name, 'before'/'after', other name)
     order = mergedTaggedValueList(schema, ORDER_KEY)
-
     for fieldName, direction, relative_to in order:
 
-        # Handle shortcut: leading . means "in this form". May be useful
+        # Handle shortcut: leading . means 'in this schema'. May be useful
         # if you want to move a field relative to one in the current
         # schema or (more likely) a base schema of the current schema, without
         # having to repeat the full prefix of this schema.

--- a/plone/autoform/view.py
+++ b/plone/autoform/view.py
@@ -6,6 +6,7 @@ from z3c.form.form import DisplayForm
 from z3c.form.interfaces import IFormLayer
 from zope.interface import implementer
 
+
 try:
     from Products.Five.bbb import AcquisitionBBB as Explicit
 except ImportError:

--- a/plone/autoform/view.txt
+++ b/plone/autoform/view.txt
@@ -43,9 +43,9 @@ A display form normally operates on a given context, although you could set
 schema interfaces need to be provided by or adaptable from the context. For
 the purposes of this test, we'll just make them directly provided.
 
-    >>> from zope.interface import implements
-    >>> class Context(object):
-    ...     implements(IDefaultSchema, ISecondarySchema)
+    >>> from zope.interface import implementer
+    >>> @implementer(IDefaultSchema, ISecondarySchema)
+    ... class Context(object):
     ...     title = u""
     ...     body = u""
     ...     summary = u""

--- a/plone/autoform/widgets.py
+++ b/plone/autoform/widgets.py
@@ -16,6 +16,7 @@ from zope.component import queryUtility
 from zope.interface import implementer
 from zope.interface import providedBy
 from zope.schema import getFields
+
 import z3c.form.browser.interfaces
 
 

--- a/plone/autoform/widgets.py
+++ b/plone/autoform/widgets.py
@@ -79,7 +79,7 @@ class ParameterizedWidget(object):
         if widget is None:
             return
         if not isinstance(widget, basestring):
-            widget = "%s.%s" % (widget.__module__, widget.__name__)
+            widget = '{0}.{1}'.format(widget.__module__, widget.__name__)
         return widget
 
     def getExportImportHandler(self, field):
@@ -93,8 +93,10 @@ class ParameterizedWidget(object):
             widgetFactory = sm.adapters.lookup(
                 (providedBy(field), IFormLayer), IFieldWidget)
             if widgetFactory is not None:
-                widgetName = "%s.%s" % (widgetFactory.__module__,
-                                        widgetFactory.__name__)
+                widgetName = '{0}.{1}'.format(
+                    widgetFactory.__module__,
+                    widgetFactory.__name__
+                )
             else:
                 widgetName = u''
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,12 @@
+[check-manifest]
+ignore =
+    *.cfg
+    bootstrap.py
+
+[isort]
+force_alphabetical_sort = True
+force_single_line = True
+lines_after_imports = 2
+line_length = 200
+not_skip = __init__.py
+

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from setuptools import find_packages
 from setuptools import setup
+
 import os
 
 
@@ -15,7 +16,7 @@ long_description = (
     + '\n' +
     read('CHANGES.rst')
     + '\n'
-    )
+)
 
 setup(
     name='plone.autoform',

--- a/setup.py
+++ b/setup.py
@@ -9,14 +9,9 @@ def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
 
-version = '1.6.3.dev0'
+version = '1.7.0.dev0'
 
-long_description = (
-    read('README.rst')
-    + '\n' +
-    read('CHANGES.rst')
-    + '\n'
-)
+long_description = (read('README.rst') + '\n' + read('CHANGES.rst'))
 
 setup(
     name='plone.autoform',


### PR DESCRIPTION
The current implementation on how field ordering happens is unreproducible if same schemas are coming in in different orders, lets demonstrate:

Given fields ``IJ.a``, ``IJ.b``  and ``IK.c`` and ``order_after(IJ.a, IJ.b)`` on ``IJ`` and ``order_after(IJ.c, IJ.a)`` on ``IK``.

1) schemas processed in order ``[IJ, IK]`` are resulting in a field order ``acb``.
2) schemas processed in order ``[IK, IJ]`` are resulting in a field order ``cba``.

This is both wrong and not good. Behaviors in the FTI are coming in different orders and I don't want us to be dependent on fragile things like orders in FTI. The example above is just with 2 schemas, in Plone we have up to about 10. Thus, we need well defined rules.

The new solution is part of the base.AutoFields class and follows strict rules by first creating a rule dependency tree. Processing the example above a rule is created for each.

How this works in detail is best taken from test_base.py unit test. 

In both cases the order is ``bac``, because rule1 is a after b ``ba`` and second rule is c after a, so ``ac``.  

I also did the usual housekeeping in separate commits.

