### PR TITLE
orderable fieldsets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,10 @@ New:
   If a different label and/or description is given, it replaces the existing prior loaded one.
   [jensens]
 
+- The order of the fieldsets can be defined now explictly with the ``plone.supermodel.directives.fieldset`` directive.
+  ``plone.autoform`` now does the sorting while fieldset processing.
+  [jensens]
+
 Fixes:
 
 - Implementation on how field ordering happens was unreproducible if same schemas are coming in in different orders.

--- a/plone/autoform/base.py
+++ b/plone/autoform/base.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from collections import OrderedDict
+from operator import attrgetter
 from plone.autoform.interfaces import ORDER_KEY
 from plone.autoform.utils import processFields
+from plone.supermodel.interfaces import DEFAULT_ORDER
 from plone.supermodel.utils import mergedTaggedValueList
 from plone.z3cform.fieldsets.group import GroupFactory
 from plone.z3cform.fieldsets.utils import move
@@ -98,8 +100,9 @@ class AutoFields(object):
                     fieldset_group = GroupFactory(
                         group_name,
                         field.Fields(),
-                        group_name,
-                        schema.__doc__
+                        label=group_name,
+                        description=schema.__doc__,
+                        order=DEFAULT_ORDER,
                     )
                     self.groups.append(fieldset_group)
 
@@ -129,6 +132,7 @@ class AutoFields(object):
             rules = self._calculate_field_moves(order, rules=rules)
         self._cleanup_rules(rules)
         self._process_field_moves(rules)
+        self._process_group_order()
 
     def getPrefix(self, schema):
         """Get the preferred prefix for the given schema
@@ -247,3 +251,6 @@ class AutoFields(object):
                         )
                     )
             self._process_field_moves(rule.get('with', {}))
+
+    def _process_group_order(self):
+        self.groups.sort(key=attrgetter('order'))

--- a/plone/autoform/directives.py
+++ b/plone/autoform/directives.py
@@ -120,7 +120,10 @@ class widget(MetadataDictDirective):
         if field_name is None:  # Usage 3
             for field_name, widget in kw.items():
                 if not isinstance(widget, basestring):
-                    widget = '%s.%s' % (widget.__module__, widget.__name__)
+                    widget = '{0}.{1}'.format(
+                        widget.__module__,
+                        widget.__name__
+                    )
                 widgets[field_name] = widget
         else:
             if widget_class is not None \

--- a/plone/autoform/widgets.py
+++ b/plone/autoform/widgets.py
@@ -67,8 +67,11 @@ class ParameterizedWidget(object):
         return widget
 
     def __repr__(self):
-        return '%s(%s, %s)' % (self.__class__.__name__,
-                               self.widget_factory, self.params)
+        return '{0}({1}, {2})'.format(
+            self.__class__.__name__,
+            self.widget_factory,
+            self.params
+        )
 
     def getWidgetFactoryName(self):
         """Returns the dotted path of the widget factory for serialization.

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,8 @@ setup(
         'zope.schema',
         'zope.security',
         'zope.dottedname',
-        'plone.supermodel>=1.1dev',
-        'plone.z3cform',
+        'plone.supermodel>=1.3.dev0',
+        'plone.z3cform>=0.9.0.dev0',
         'z3c.form',
         # 'AccessControl',
         # -*- Extra requirements: -*-


### PR DESCRIPTION
Fieldsets can be explicit ordered now. This was possible with AT/ATCT, but was lost with z3cforms in dexterity. 

Changes in plone.z3cform and plone.supermodel were already merged. Default order 9999 is set if nothing else was set. ``Default`` fieldset is always first, because it is not a group of the form, but the form fields directly on the form. 
