### PR TITLE
fix if no schema and no additionalSchemata are found

### DIFF
--- a/plone/autoform/base.py
+++ b/plone/autoform/base.py
@@ -119,7 +119,7 @@ class AutoFields(object):
         # Then process relative field movements. The base schema is processed
         # last to allow it to override any movements made in additional
         # schemata.
-        rules = None
+        rules = {}
         for schema in self.additionalSchemata:
             order = mergedTaggedValueList(schema, ORDER_KEY)
             rules = self._calculate_field_moves(


### PR DESCRIPTION
self._cleanup_rules(rules)
self._process_field_moves(rules)
are breaking if there is no schema and no additionalSchemata:

def _cleanup_rules(self, rules):
        for rulename in rules['__all__']:
if rules is None, it will throw an error.