### PR TITLE
Fix updateFieldsFromSchemata for schemaless forms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix traceback in updateFieldsFromSchemata for forms with no schema.
+  [davisagli]
 
 
 1.7.2 (2017-04-01)

--- a/plone/autoform/base.py
+++ b/plone/autoform/base.py
@@ -119,7 +119,7 @@ class AutoFields(object):
         # Then process relative field movements. The base schema is processed
         # last to allow it to override any movements made in additional
         # schemata.
-        rules = None
+        rules = {'__all__': {}}
         for schema in self.additionalSchemata:
             order = mergedTaggedValueList(schema, ORDER_KEY)
             rules = self._calculate_field_moves(

--- a/plone/autoform/tests/test_base.py
+++ b/plone/autoform/tests/test_base.py
@@ -119,3 +119,9 @@ class TestBase(unittest.TestCase):
         self.assertIn('z', rules)
         self.assertNotIn('a', rules)
         self.assertNotIn('c', rules)
+
+    def test_updateFieldsFromSchemata(self):
+        from plone.autoform.base import AutoFields
+        autofields = AutoFields()
+        autofields.updateFieldsFromSchemata()
+        # (the assertion is that is doesn't break)

--- a/plone/autoform/tests/test_base.py
+++ b/plone/autoform/tests/test_base.py
@@ -125,4 +125,4 @@ class TestBase(unittest.TestCase):
         autofields = AutoFields()
         autofields.request = {}
         autofields.updateFieldsFromSchemata()
-        # (the assertion is that is doesn't break)
+        self.assertEqual(autofields.groups, [])

--- a/plone/autoform/tests/test_base.py
+++ b/plone/autoform/tests/test_base.py
@@ -123,5 +123,6 @@ class TestBase(unittest.TestCase):
     def test_updateFieldsFromSchemata(self):
         from plone.autoform.base import AutoFields
         autofields = AutoFields()
+        autofields.request = {}
         autofields.updateFieldsFromSchemata()
         # (the assertion is that is doesn't break)


### PR DESCRIPTION
This fixes a traceback I was getting in add forms for tiles that have no schema.