### PR TITLE
Reduce field move failure logging from error to warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ New features:
 
 Bug fixes:
 
+- Reduce field move failure logging from error to warning.
+  Log more information like full rule.
+  [jensens]
+
 - Fix traceback in updateFieldsFromSchemata for forms with no schema.
   [davisagli]
 

--- a/plone/autoform/base.py
+++ b/plone/autoform/base.py
@@ -241,15 +241,21 @@ class AutoFields(object):
                     )
                 try:
                     move(self, name, before=before, after=after, prefix=prefix)
-                except KeyError:
-                    # The relative_to field doesn't exist
-                    logger.exception(
-                        'No field move possible for non-existing field named '
-                        '{0} with target {1}'.format(
-                            prefix + '.' + name,
-                            before or after
+                except KeyError as e:
+                    if (
+                        e.message.startswith('Field ') and
+                        e.message.endswith(' not found')
+                    ):
+                        # The relative_to field doesn't exist
+                        logger.warning(
+                            'Field move to non-existing: '
+                            'field name: {0}, rule: {1}'.format(
+                                prefix + '.' + name,
+                                str(rule)
+                            )
                         )
-                    )
+                    else:
+                        raise
             self._process_field_moves(rule.get('with', {}))
 
     def _process_group_order(self):


### PR DESCRIPTION
Also, reduce the amount of logged text while increasing information given.

before:

```
2017-05-17 11:49:53 ERROR plone.autoform.base No field move possible for non-existing field named IBasic.description with target *
Traceback (most recent call last):
  File "/home/workspacejensens/pro/akifair/srccore/plone.autoform/plone/autoform/base.py", line 243, in _process_field_moves
    move(self, name, before=before, after=after, prefix=prefix)
  File "/home/jensens/.buildout/shared-eggs/plone.z3cform-0.9.0-py2.7.egg/plone/z3cform/fieldsets/utils.py", line 85, in move
    raise KeyError("Field %s not found" % field_name)
KeyError: 'Field IBasic.description not found'
```

After:

```
2017-05-17 12:04:54 WARNING plone.autoform.base Field move to non-existing: field name: IBasic.description, rule: {'target': '*', 'dir': 'before'}
```
