### PR TITLE
Allow fieldset configuration via field-less schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Breaking changes:
 
 New features:
 
+- Allow configuration of fieldsets via ``plone.supermodel`` fieldset directives via a schema without fields.
+  This can be used to create a Plone behavior for stable ordering of fieldsets.
+  [thet]
+
 - Add handler registration for text input widgets to support e.g. 'placeholder'
   parameter in parameterized widgets
   [datakurre]

--- a/plone/autoform/tests/test_utils.py
+++ b/plone/autoform/tests/test_utils.py
@@ -93,3 +93,42 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(len(form.groups), 1)
         self.assertEqual(len(form.groups[0].fields), 2)
         self.assertEqual([g.__name__ for g in form.groups], ['custom'])
+
+    def test_fieldset_configuration(self):
+        """Test, if fieldsets can be orderd via fieldset configuration on a 
+        schema without fields. This schema should also not be included in form
+        groups.
+        """
+        form = Form(None, None)
+        form.groups = []
+
+        class schema1(Interface):
+            title = zope.schema.TextLine()
+
+        fs1 = Fieldset('fs1', label=u'fs1', fields=['title'])
+        schema1.setTaggedValue(FIELDSETS_KEY, [fs1])
+
+        class schema2(Interface):
+            subtitle = zope.schema.TextLine()
+
+        fs2 = Fieldset('fs2', label=u'fs2', fields=['subtitle'])
+        schema2.setTaggedValue(FIELDSETS_KEY, [fs2])
+
+        class schema3(Interface):
+            pass
+
+        fs3 = Fieldset('fs1', order=2)
+        fs4 = Fieldset('fs2', order=1)
+        schema3.setTaggedValue(FIELDSETS_KEY, [fs3, fs4])
+       
+        processFields(form, schema1, prefix='prefix', permissionChecks=True)
+        processFields(form, schema2, prefix='prefix', permissionChecks=True)
+        processFields(form, schema3, prefix='prefix', permissionChecks=True)
+
+        self.assertEqual(len(form.groups), 2)
+
+        self.assertEqual(form.groups[0].__name__, 'fs1')
+        self.assertEqual(form.groups[0].order, 2)
+
+        self.assertEqual(form.groups[1].__name__, 'fs2')
+        self.assertEqual(form.groups[1].order, 1)

--- a/plone/autoform/utils.py
+++ b/plone/autoform/utils.py
@@ -160,21 +160,10 @@ def _process_fieldsets(
             *[_process_prefixed_name(prefix, name) for name in fieldset.fields
               if _process_prefixed_name(prefix, name) in all_fields]
         )
-        if not (
-            getattr(form, 'showEmptyGroups', False) or
-            len(new_fields) > 0
-        ):
-            continue
-        _process_widgets(form, widgets, modes, new_fields)
-        if fieldset.__name__ not in groups:
-            group = GroupFactory(fieldset.__name__,
-                                 label=fieldset.label,
-                                 description=fieldset.description,
-                                 order=fieldset.order,
-                                 fields=new_fields)
-            form.groups.append(group)
-            groups[group.__name__] = group
-        else:
+
+        if fieldset.__name__ in groups:
+            # Process also, if no fields are defined to allow fieldset-only
+            # configurations via plone.supermodel fieldset directive.
             group = groups[fieldset.__name__]
             group.fields += new_fields
             if (
@@ -194,6 +183,17 @@ def _process_fieldsets(
                 fieldset.order != group.order
             ):
                 group.order = fieldset.order
+
+        if len(new_fields) > 0 or getattr(form, 'showEmptyGroups', False):
+            _process_widgets(form, widgets, modes, new_fields)
+            if fieldset.__name__ not in groups:
+                group = GroupFactory(fieldset.__name__,
+                                     label=fieldset.label,
+                                     description=fieldset.description,
+                                     order=fieldset.order,
+                                     fields=new_fields)
+                form.groups.append(group)
+                groups[group.__name__] = group
 
 
 def _process_permissions(schema, form, all_fields):


### PR DESCRIPTION
Allow configuration of fieldsets via ``plone.supermodel`` fieldset directives via a schema without fields.
This can be used to create a Plone behavior for stable ordering of fieldsets.