### PR TITLE
Remove reference to grok for autoform.rst

### DIFF
--- a/plone/autoform/autoform.rst
+++ b/plone/autoform/autoform.rst
@@ -26,7 +26,8 @@ There are several ways to set the form data:
 * By loading the schema from a plone.supermodel XML file. This package
   provides a schema handler for the 'form' prefix that can be used to
   incorporate form hints. See supermodel.txt for details.
-* By using the grok directives in the plone.directives.form package.
+* By using the directives from ``plone.autoform.directives`` while defining
+  a schema in Python.
 
 For the purposes of this test, we'll set the form data manually.
 


### PR DESCRIPTION
This is the same change made to README.txt in https://github.com/plone/plone.autoform/commit/689cdfb416ae2adf33062335a836cf2c3621822f#diff-26fd799ea07494916e9da9b91b2aac64