### PR TITLE
Remove the dummy security manager on test tear down

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Remove the dummy security manager on test tear down
+  [ale-rt]
 
 
 1.8.0 (2018-09-26)

--- a/plone/autoform/tests/test_utils.py
+++ b/plone/autoform/tests/test_utils.py
@@ -41,6 +41,9 @@ class TestUtils(unittest.TestCase):
         self.secman = DummySecurityManager()
         setSecurityManager(self.secman)
 
+    def tearDown(self):
+        noSecurityManager()
+
     def test_processFields_permissionChecks_no_prefix(self):
         form = Form(None, None)
         form.groups = ()

--- a/plone/autoform/tests/test_utils.py
+++ b/plone/autoform/tests/test_utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from AccessControl.SecurityManagement import noSecurityManager
 from AccessControl.SecurityManagement import setSecurityManager
+from AccessControl.SecurityManagement import getSecurityManager
 from plone.autoform.interfaces import WRITE_PERMISSIONS_KEY
 from plone.autoform.utils import processFields
 from plone.supermodel.interfaces import FIELDSETS_KEY
@@ -38,11 +38,12 @@ class TestUtils(unittest.TestCase):
                 self.checks.append(perm)
                 return False
 
+        self.oldsecman = getSecurityManager()
         self.secman = DummySecurityManager()
         setSecurityManager(self.secman)
 
     def tearDown(self):
-        noSecurityManager()
+        setSecurityManager(self.oldsecman)
 
     def test_processFields_permissionChecks_no_prefix(self):
         form = Form(None, None)


### PR DESCRIPTION
Refs. https://github.com/plone/Products.CMFPlone/issues/2560

Note: the tearDown was removed in #32